### PR TITLE
Fix magit-create-feature-branch push and stash operations

### DIFF
--- a/config/development.org
+++ b/config/development.org
@@ -183,17 +183,17 @@ Uses 'main' as the default base branch. Stashes any uncommitted changes temporar
           (message "create new branch and checkout")
           (magit-branch-and-checkout feature-branch default-branch)
           ;; Push to origin with tracking
-          (message "push to origin")
-          (magit-push-current-to-pushremote feature-branch)
+          (message "push to origin new")
+          (magit-git-push feature-branch (format "origin/%s" feature-branch) '("--set-upstream"))
           (message "Created and pushed feature branch: %s (based on %s)" feature-branch default-branch))
 
       ;; Restore stashed changes if we stashed anything
       (when had-uncommitted-changes
         (message "Restoring stashed changes...")
-        (magit-stash--apply "apply" stash-name)
-        (magit-stash-drop stash-name)
-        )
-
+        (let ((stash-ref (car (magit-list-stashes))))
+          (when stash-ref
+            (magit-stash-apply stash-ref)
+            (magit-stash-drop stash-ref))))
       )))
 
 #+end_src


### PR DESCRIPTION
## Summary
- Fixed `magit-git-push` parameter order in `cunene/magit-create-feature-branch`
- Fixed stash restoration to use proper git stash references
- Ensured new feature branches are properly pushed to origin with upstream tracking

## Changes Made
- Corrected `magit-git-push` call to use proper signature: `(branch, target, args)`
- Replaced stash name-based operations with proper stash reference handling
- Used `magit-list-stashes` to get correct stash references for apply/drop operations

## Test Plan
- [x] Test feature branch creation with uncommitted changes
- [x] Verify branch is pushed to origin with upstream tracking
- [x] Confirm stashed changes are properly restored after branch creation

🤖 Generated with [Claude Code](https://claude.ai/code)