### PR TITLE
Wire dark mode CSS into the site build

### DIFF
--- a/.build-site.el
+++ b/.build-site.el
@@ -49,10 +49,10 @@
 ;; Load the publishing system
 (require 'ox-publish)
 
-(defvar html-header "<link id=\"pagestyle\" rel=\"stylesheet\" type=\"text/css\" href=\"https://gongzhitaao.org/orgcss/org.css\"/>
+(defvar html-header "<link id=\"pagestyle\" rel=\"stylesheet\" type=\"text/css\" href=\"/cunene/assets/css/org.css\"/>
 <script src=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/highlight.min.js\"></script>
 <script>var hlf=function(){Array.prototype.forEach.call(document.querySelectorAll(\"pre.src\"),function(t){var e;e=t.getAttribute(\"class\"),e=e.replace(/src-(\w+)/,\"src-$1 $1\"),console.log(e),t.setAttribute(\"class\",e),hljs.highlightBlock(t)})};addEventListener(\"DOMContentLoaded\",hlf);</script>
-<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/googlecode.min.css\" />")
+<link rel=\"stylesheet\" href=\"https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.10.0/styles/atom-one-dark.min.css\" />")
 
 ;; Customize the HTML output
 (setq org-html-validation-link nil            ;; Don't show validation link
@@ -79,7 +79,12 @@
          :base-extension "png\\|jpg\\|gif\\|svg"
          :publishing-directory "./build/output/site/assets/images"
          :publishing-function org-publish-attachment)
-        ("site:main" :components("site:pages" "site:images"))))
+        ("site:css"
+         :base-directory "./assets/css"
+         :base-extension "css"
+         :publishing-directory "./build/output/site/assets/css"
+         :publishing-function org-publish-attachment)
+        ("site:main" :components("site:pages" "site:images" "site:css"))))
 
 ;; Generate the site output
 (org-publish-all t)


### PR DESCRIPTION
## Summary
Follow-up to #24. That PR replaced `assets/css/org.css` with the dark theme but the published site still pulled CSS from `gongzhitaao.org/orgcss/org.css` and never deployed the local file — so the live site stayed light.

- Point the `html-header` stylesheet at `/cunene/assets/css/org.css` (absolute path; site is served at `/cunene/`)
- Switch highlight.js theme to `atom-one-dark` so code blocks match the dark body
- Add a `site:css` publish target so the CSS lands in `build/output/site/assets/css/`

Mirrors how [mcraveiro.github.io](https://github.com/mcraveiro/mcraveiro.github.io) wires up its own dark CSS.

## Test plan
- [ ] Workflow runs cleanly after merge
- [ ] https://mcraveiro.github.io/cunene/ renders with dark background
- [ ] https://mcraveiro.github.io/cunene/assets/css/org.css returns 200
- [ ] Code blocks render with atom-one-dark syntax colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)